### PR TITLE
Fix upgrade-spaces (old page was removed)

### DIFF
--- a/src/Octopurls/redirects.json
+++ b/src/Octopurls/redirects.json
@@ -54,7 +54,7 @@
   "TrainingVideos": "https://www.youtube.com/watch?v=FOxqnle2bCc&list=PLAGskdGvlaw3Aj25_77wK1BMtIryTye51",
   "GettingStarted": "https://octopus.com/docs/getting-started",
   "Upgrade2To3": "https://octopus.com/docs/administration/upgrading/upgrading-from-octopus-2.6",
-  "UpgradeSpaces": "https://octopus.com/upgrade-spaces?utm_source=product&utm_medium=popup&utm_campaign=opj&utm_term=upgrade-spaces",
+  "UpgradeSpaces": "https://octopus.com/spaces",
   "HighAvailability": "https://octopus.com/docs/administration/high-availability",
   "SecurityAndEncryption": "https://octopus.com/docs/administration/security/data-encryption",
   "VersioningHelp": "https://octopus.com/docs/deployment-process/channels#Channels-VersionRange",


### PR DESCRIPTION
- The old `UpgradeSpaces` page was removed in https://github.com/OctopusDeploy/Octofront/commit/68e0349771d43a4b6216445a2d690497537bb0c8, and an internal redirect was added from to `/spaces` in https://github.com/OctopusDeploy/Octofront/commit/a18f55d4982f9c036e486bdf8cda07224bc00d87#diff-a3b1ed6e7bf6998f1a0e7e233d5bc58aR1066, but this doesn't work when a query string is included. 
- [As discussed](https://octopusdeploy.slack.com/archives/C625CE6R3/p1552255215004100), this PR updates the Octopurl to directly link to `/spaces` (with no query string)