### PR TITLE
Update arc link

### DIFF
--- a/src/Octopurls/redirects.json
+++ b/src/Octopurls/redirects.json
@@ -101,7 +101,7 @@
   "DeploymentTargets": "https://octopus.com/docs/infrastructure",
   "ProjectTenantedDeploymentMode": "https://octopus.com/docs/deployment-patterns/multi-tenant-deployments/multi-tenant-deployment-guide/deploying-a-simple-multi-tenant-project",
   "LibraryVariableSets": "https://octopus.com/docs/projects/variables/library-variable-sets",
-  "AutoReleaseCreation": "https://octopus.com/docs/managing-releases/automatic-release-creation",
+  "AutoReleaseCreation": "https://octopus.com/docs/projects/project-triggers/automatic-release-creation",
   "Subscriptions": "https://octopus.com/docs/administration/managing-infrastructure/subscriptions",
   "AuthGuest": "http://docs.octopus.com/display/OD/Guest+login",
   "AuthAD": "http://docs.octopus.com/display/OD/Active+Directory+authentication",


### PR DESCRIPTION
# Issue: 
Help on triggers page is broken. It is going to https://octopus.com/docs/managing-releases/automatic-release-creation i/o https://octopus.com/docs/projects/project-triggers/automatic-release-creation 

![image](https://user-images.githubusercontent.com/48192575/74990855-291cd280-5490-11ea-91cb-d268d34cd72e.png)
