### PR TITLE
Missing Link on Jira Integration Page in Octopus

### DIFF
--- a/src/Octopurls/redirects.json
+++ b/src/Octopurls/redirects.json
@@ -510,5 +510,6 @@
   "TargetWildflySamplePetClinic": "https://samples.octopus.app/app#/Spaces-85/projects/petclinic/",
   "PatternRollingSampleWindowSize": "https://samples.octopus.app/app#/Spaces-45/projects/window-size-as-percentage",
   "PatternRollingSampleIncrementCounter": "https://samples.octopus.app/app#/Spaces-45/projects/increment-rolling-counter",
-  "PatternRollingSampleManualRolling": "https://samples.octopus.app/app#/Spaces-45/projects/manual-rolling-deployments"
+  "PatternRollingSampleManualRolling": "https://samples.octopus.app/app#/Spaces-45/projects/manual-rolling-deployments",
+  "JiraIntegration": "https://octopus.com/docs/managing-releases/issue-tracking/jira"
 }


### PR DESCRIPTION
Learn More link on configuration/settings/jira-integration links through to a dead link. This fixes the dead link