### PR TITLE
Add redirect for AccessDeniedStartingHttpListener

### DIFF
--- a/src/Octopurls/redirects.json
+++ b/src/Octopurls/redirects.json
@@ -586,7 +586,7 @@
   "DockerTags": "https://docs.docker.com/engine/reference/commandline/tag/#extended-description",
   "Workers": "https://octopus.com/docs/infrastructure/workers",
   "ReleaseVersioning": "https://octopus.com/docs/releases/release-versioning",
-  "ReleaseNotes": "https://octopus.com/docs/releases/release-notes",
   "DynamicInfrastructure": "https://octopus.com/docs/infrastructure/deployment-targets/dynamic-infrastructure",
-  "DiscreteChannelReleases": "https://octopus.com/docs/releases/channels"
+  "DiscreteChannelReleases": "https://octopus.com/docs/releases/channels",
+  "AccessDeniedStartingHttpListener": "https://octopus.com/docs/support/troubleshooting-access-denied-starting-http-listener"
 }


### PR DESCRIPTION
Prior to 2021.1.0, we used a manifest to demand administrator permissions on Windows. Now, we log a nice error message instead when we don't have permissions. This error message includes an octopurl to the docs page.

Relates to https://github.com/OctopusDeploy/docs/pull/1156
Relates to OctopusDeploy/OctopusDeploy#7925