### PR TITLE
Add KubernetesCloudTargetDiscovery URL

### DIFF
--- a/source/Octopurls/redirects.json
+++ b/source/Octopurls/redirects.json
@@ -700,6 +700,7 @@
   "DDOG": "https://github.com/weeyin83/Presentations/blob/main/2022/gettingstartedwithoctopus/resources.md",
   "CloudTargetDiscovery": "https://octopus.com/docs/infrastructure/deployment-targets/cloud-target-discovery",
   "CloudTargetDiscoveryFeedbackForm": "https://octopusdeploy.typeform.com/to/PNaHQRoN",
+  "KubernetesCloudTargetDiscovery": "https://oc.to/KubernetesCloudTargetDiscovery",
   "superpowers": "https://github.com/weeyin83/Presentations/tree/main/2022/superpowerscombine",
   "bicepoctopus": "https://github.com/weeyin83/Presentations/tree/main/2022/bicepoctopus",
   "MultiTenantChannels": "https://octopus.com/docs/tenants/tenant-lifecycles",


### PR DESCRIPTION
This needs to be added for Octopus 2022.2 where the Kubernetes Cloud Target Discovery EAP switch will be added in [this PR](https://github.com/OctopusDeploy/OctopusDeploy/pull/12284).

I've set this up to use https://oc.to/KubernetesCloudTargetDiscovery because currently the forwarding address in short.io is the same as CloudTargetDiscovery but once the documentation is complete for the Kubernetes specific Cloud Target Discovery, I will update the short.io link which will mean this link is updated without another PR required.

In the latest version of Octopus front end, short.io will be used because of [this pr](https://github.com/OctopusDeploy/OctopusDeploy/pull/12295).